### PR TITLE
Feature/update packages, fix sonarscan

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -73,9 +73,9 @@ jobs:
         shell: powershell
         # Tests, CodeCoverage and collection of these results. Only repository and services are included in CodeCoverage.
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"ricardotill_SSSKLv2" /o:"ricardotill" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="SSSKLv2.Test/coverage.opencover.xml"
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"ricardotill_SSSKLv2" /o:"ricardotill" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="SSSKLv2.Test/coverage.opencover.xml"
           dotnet build SSSKLv2.sln
           dotnet test --no-build --verbosity normal
           dotnet test SSSKLv2.sln /p:CollectCoverage=true /p:CoverletOutput=coverage /p:CoverletOutputFormat=opencover /p:ExcludeByFile="**/Migrations/**/*.cs%2c**/Components/**/*.cs%2c**/Controllers/**/*.cs%2c**/Pages/**/*.cs%2c**/ServiceExtensions.cs%2c**/Program.cs"
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login=${{ secrets.SONAR_TOKEN }}
       - run: dotnet --version

--- a/SSSKLv2.Test/SSSKLv2.Test.csproj
+++ b/SSSKLv2.Test/SSSKLv2.Test.csproj
@@ -10,17 +10,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.4.0" />
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="Bogus" Version="35.6.1" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.71" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/SSSKLv2/Components/Pages/About.razor
+++ b/SSSKLv2/Components/Pages/About.razor
@@ -8,7 +8,7 @@
     </div>
     <div class="col-9">
         <h1 class="fst-italic">
-            SSSKL <span class="badge text-bg-primary">v2.2</span><br/>
+            SSSKL <span class="badge text-bg-primary">v2.3.0</span><br/>
         </h1>
         
         <p>Made with ❤️ by <span class="text-nowrap"><a href="https://ricardotill.nl/" target=”_blank”>Ricardo Tillemans</a></span></p>

--- a/SSSKLv2/Components/Pages/About.razor
+++ b/SSSKLv2/Components/Pages/About.razor
@@ -8,7 +8,7 @@
     </div>
     <div class="col-9">
         <h1 class="fst-italic">
-            SSSKL <span class="badge text-bg-primary">v2.3.0</span><br/>
+            SSSKL <span class="badge text-bg-primary">v2.3.1</span><br/>
         </h1>
         
         <p>Made with ❤️ by <span class="text-nowrap"><a href="https://ricardotill.nl/" target=”_blank”>Ricardo Tillemans</a></span></p>

--- a/SSSKLv2/Components/Pages/Home.razor
+++ b/SSSKLv2/Components/Pages/Home.razor
@@ -12,6 +12,55 @@
 
 <h4 class="mb-1">Changenotes</h4>
 <div class="mb-1">
+    <h5>2.3.0 : 08-04-2024</h5>
+    <p>
+        <ul>
+            <li>
+                Sub-menu items are no longer red, but grey.
+            </li>
+            <li>
+                When saldo is negative, the saldo is now red.
+            </li>
+        </ul>
+    </p>
+</div>
+<div class="mb-1">
+    <h5>2.2.0 : 27-03-2024</h5>
+    <p>
+        <ul>
+            <li>
+                Added support azure sql sleeping databases, by introducing sql server resiliency.
+            </li>
+        </ul>
+    </p>
+</div>
+<div class="mb-1">
+    <h5>2.1.2 : 21-02-2024</h5>
+    <p>
+        <ul>
+            <li>
+                Added menu-option for usersettings
+            </li>
+        </ul>
+    </p>
+</div>
+<div class="mb-1">
+    <h5>2.1.1 : 20-02-2024</h5>
+    <p>
+        <ul>
+            <li>
+                Added 'Login' Call to Action button to Homescreen.
+            </li>
+            <li>
+                Update Packages
+            </li>
+            <li>
+                Bugfixes
+            </li>
+        </ul>
+    </p>
+</div>
+<div class="mb-1">
     <h5>2.1.0 : 14-02-2024</h5>
     <p>
         <b>Added "Guest" role</b>

--- a/SSSKLv2/Components/Pages/Home.razor
+++ b/SSSKLv2/Components/Pages/Home.razor
@@ -12,6 +12,16 @@
 
 <h4 class="mb-1">Changenotes</h4>
 <div class="mb-1">
+    <h5>2.3.1 : 06-09-2024</h5>
+    <p>
+    <ul>
+        <li>
+            Removed vulnerabilities by updating its packages.
+        </li>
+    </ul>
+    </p>
+</div>
+<div class="mb-1">
     <h5>2.3.0 : 08-04-2024</h5>
     <p>
         <ul>

--- a/SSSKLv2/SSSKLv2.csproj
+++ b/SSSKLv2/SSSKLv2.csproj
@@ -32,29 +32,29 @@
 
   <ItemGroup>
     <PackageReference Include="BlazorComponentUtilities" Version="1.8.0" />
-    <PackageReference Include="Blazored.Toast" Version="4.2.0" />
-    <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="Blazored.Toast" Version="4.2.1" />
+    <PackageReference Include="FluentValidation" Version="11.9.2" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter" Version="8.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Azure.SignalR" Version="1.24.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.2">
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.3.0" />
+    <PackageReference Include="Microsoft.Azure.SignalR" Version="1.27.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.1" />
-    <PackageReference Include="Polly" Version="8.3.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.4" />
+    <PackageReference Include="Polly" Version="8.4.1" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageReference Include="QRCoder" Version="1.4.3" />
-    <PackageReference Include="SendGrid" Version="9.29.2" />
+    <PackageReference Include="QRCoder" Version="1.6.0" />
+    <PackageReference Include="SendGrid" Version="9.29.3" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- Update Nuget packages
  - Some packages were severely out of date, this has now been fixed.
- Fix SonarScan
  - Sonarscan had some issues regarding the invocation and the usage of a token. This has now been fixed.
- Bump versioning and its changelog.